### PR TITLE
describe how to use black to format code style to pep 8

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,19 @@
+# Python Plugins
+
+## Automated, In-Place, PEP 8 Formatting
+
+Install (black)[https://github.com/psf/black] as a development dependency.
+
+```shell
+pip install --user black
+```
+
+Tell `black` to edit `your_plugin.py` to make its code style conform to
+`black`'s code style, a strict subset of PEP 8.
+
+```shell
+black --preview --experimental-string-processing <your_plugin.py>
+```
+
+This should perform most of the necessary style formatting. Updates to this method
+are recommended.


### PR DESCRIPTION
## Changes introduced with this PR

Add a readme to describe how to use the Python code formater, black, to automatically format python source code to the black code style, a strict subset of the PEP 8 code style.
---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).