### PR TITLE
install smallfile from release build instead of github tag

### DIFF
--- a/python/smallfile/Dockerfile
+++ b/python/smallfile/Dockerfile
@@ -1,16 +1,23 @@
+ARG SMALLFILE_VERSION="1.1"
+
 #stage 1
 FROM quay.io/centos/centos:stream8
 
-RUN dnf install -y git
+ARG SMALLFILE_VERSION
+
+RUN dnf install -y wget
 
 RUN mkdir /smallfile
 RUN chmod 777 /smallfile
 WORKDIR /smallfile
 USER 1000
-RUN git clone -b 1.1 --single-branch https://github.com/distributed-system-analysis/smallfile.git
+RUN wget https://github.com/distributed-system-analysis/smallfile/archive/refs/tags/${SMALLFILE_VERSION}.tar.gz
+RUN tar xzf ${SMALLFILE_VERSION}.tar.gz
 
 #stage 2
 FROM quay.io/centos/centos:stream8
+
+ARG SMALLFILE_VERSION
 
 RUN dnf module -y install python39 && dnf install -y python39 python39-pip
 
@@ -23,7 +30,7 @@ ADD requirements.txt /plugin
 ADD smallfile-example.yaml /plugin
 ADD https://raw.githubusercontent.com/arcalot/arcaflow-plugins/main/LICENSE /plugin
 RUN chmod +x /plugin/smallfile_plugin.py /plugin/test_smallfile_plugin.py
-COPY --from=0 /smallfile/smallfile /plugin/smallfile
+COPY --from=0 /smallfile/smallfile-${SMALLFILE_VERSION} /plugin/smallfile
 RUN chmod 777 /plugin/smallfile
 WORKDIR /plugin
 


### PR DESCRIPTION
## Changes introduced with this PR

Fixes #22, installing smallfile from a release build.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).