### PR TITLE
fio: help noticing fio package is missing

### DIFF
--- a/python/fio/fio_plugin.py
+++ b/python/fio/fio_plugin.py
@@ -43,6 +43,15 @@ def run(
 
         return "success", output
 
+    except FileNotFoundError as exc:
+        if exc.filename == "fio":
+            error_output: FioErrorOutput = FioErrorOutput(
+                "missing fio executable, please install fio package"
+            )
+        else:
+            error_output: FioErrorOutput = FioErrorOutput(format_exc())
+        return "error", error_output
+
     except Exception:
         error_output: FioErrorOutput = FioErrorOutput(format_exc())
         return "error", error_output

--- a/python/fio/test_fio_plugin.py
+++ b/python/fio/test_fio_plugin.py
@@ -3,6 +3,7 @@
 import unittest
 import json
 from pathlib import Path
+import sys
 
 import yaml
 from arcaflow_plugin_sdk import plugin
@@ -44,6 +45,13 @@ class FioPluginTest(unittest.TestCase):
         job.cleanup = False
         output_id, output_data = fio_plugin.run(job)
 
+        # if the command didn't succeed, fio-plus.json won't exist.
+        try:
+            self.assertEqual("success", output_id)
+        except AssertionError as e:
+            sys.stderr.write("Error: {}\n".format(output_data.error))
+            raise
+
         with open("fio-plus.json", "r") as fio_output_file:
             fio_results = fio_output_file.read()
             output_actual: fio_plugin.FioSuccessOutput = (
@@ -52,7 +60,6 @@ class FioPluginTest(unittest.TestCase):
                 )
             )
 
-        self.assertEqual("success", output_id)
         self.assertEqual(output_data, output_actual)
 
         Path("fio-plus.json").unlink(missing_ok=True)


### PR DESCRIPTION
## Changes introduced with this PR

Fixes #42 by providing a more useful error when fio package is missing:
```console
$ python test_fio_plugin.py 
Error: missing fio executable, please install fio package
F.
======================================================================
FAIL: test_functional_success (__main__.FioPluginTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "~/arcaflow-plugins/python/fio/test_fio_plugin.py", line 50, in test_functional_success
    self.assertEqual("success", output_id)
AssertionError: 'success' != 'error'
- success
+ error


----------------------------------------------------------------------
Ran 2 tests in 0.010s

FAILED (failures=1)

```

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>